### PR TITLE
Make the scripts more portable

### DIFF
--- a/src/replace_landsurface_with_BARRA2R_IC.py
+++ b/src/replace_landsurface_with_BARRA2R_IC.py
@@ -8,8 +8,9 @@ from pathlib import Path
 import xarray as xr, sys, argparse
 from datetime import datetime,timedelta
 
+ROSE_DATA = os.environ.get('ROSE_DATA')
 # Base directory of the ERA5-land archive on NCI
-BARRA_DIR = '/g/data/ob53/BARRA2/output/reanalysis/AUS-11/BOM/ERA5/historical/hres/BARRA-R2/v1/'
+BARRA_DIR = os.path.join(ROSE_DATA, 'etc', 'barra_r2')
 
 
 class ReplaceOperator(mule.DataOperator):
@@ -191,9 +192,9 @@ def swap_land_barra(mask_fullpath, ec_cb_file_fullpath, ic_date):
 
     # Read in the surface temperature data from the archive
     BARRA_FIELDN = 'ts'
-    indir = BARRA_DIR + '1hr/' + BARRA_FIELDN + '/v20231001'
-    barra_files = glob(indir + '/' + BARRA_FIELDN + '*' + yyyy + mm + '*nc')
-    barra_fname = indir + '/' + barra_files[0].split('/')[-1]
+    indir = os.path.join(BARRA_DIR, '1hr', BARRA_FIELDN, 'v20231001')
+    barra_files = glob(os.path.join(indir, BARRA_FIELDN + '*' + yyyy + mm + '*nc'))
+    barra_fname = os.path.join(indir, os.path.basename(barra_files[0]))
 
     # Work out the grid bounds using the surface temperature file
     bounds = bounding_box(barra_fname, mask_fullpath.as_posix(), "land_binary_mask")
@@ -204,17 +205,17 @@ def swap_land_barra(mask_fullpath, ec_cb_file_fullpath, ic_date):
     
     # Read in the soil moisture data (and keep to use for replacement)
     BARRA_FIELDN = 'mrsol'
-    indir = BARRA_DIR + '/3hr/' + BARRA_FIELDN + '/v20231001'
-    barra_files = glob(indir + '/' + BARRA_FIELDN + '*' + yyyy + mm + '*nc')
-    barra_fname = indir + '/' + barra_files[0].split('/')[-1]
+    indir = os.path.join(BARRA_DIR, '3hr', BARRA_FIELDN, 'v20231001')
+    barra_files = glob(os.path.join(indir, BARRA_FIELDN + '*' + yyyy + mm + '*nc'))
+    barra_fname = os.path.join(indir, os.path.basename(barra_files[0]))
     data = get_BARRA_nc_data(barra_fname, BARRA_FIELDN, ic_date.replace('T', '').replace('Z', ''), 4, bounds)
     mrsol = data.copy()
 
     # Read in the soil temperature data (and keep to use for replacement)
     BARRA_FIELDN = 'tsl'
-    indir = BARRA_DIR + '3hr/' + BARRA_FIELDN + '/v20231001'
-    barra_files = glob(indir + '/' + BARRA_FIELDN + '*' + yyyy + mm + '*nc')
-    barra_fname = indir + '/' + barra_files[0].split('/')[-1]
+    indir = os.path.join(BARRA_DIR, '3hr', BARRA_FIELDN, 'v20231001')
+    barra_files = glob(os.path.join(indir, BARRA_FIELDN + '*' + yyyy + mm + '*nc'))
+    barra_fname = os.path.join(indir, os.path.basename(barra_files[0]))
     data = get_BARRA_nc_data(barra_fname, BARRA_FIELDN, ic_date.replace('T', '').replace('Z', ''), 4, bounds)
     tsl = data.copy()
     

--- a/src/replace_landsurface_with_ERA5land_IC.py
+++ b/src/replace_landsurface_with_ERA5land_IC.py
@@ -8,8 +8,9 @@ from pathlib import Path
 import xarray as xr, sys, argparse
 from datetime import datetime,timedelta
 
+ROSE_DATA = os.environ.get('ROSE_DATA')
 # Base directory of the ERA5-land archive on NCI
-ERA_DIR = '/g/data/zz93/era5-land/reanalysis/'
+ERA_DIR = os.path.join(ROSE_DATA, 'etc', 'era5_land')
 
 # The depths of soil for the conversion
 ##########multipliers=[7.*10., 21.*10., 72.*10., 189.*10.]
@@ -220,9 +221,9 @@ def swap_land_era5land(mask_fullpath, ic_file_fullpath, ic_date):
 
     # Find one "swvl1" file in the archive and create a generic filename
     ERA_FIELDN = 'swvl1'
-    land_yes = ERA_DIR + ERA_FIELDN + '/' + yyyy + '/'
-    era_files = glob(land_yes + '/' + ERA_FIELDN + '*' + yyyy + mm + '*nc')
-    era5_fname = land_yes + '/' + era_files[0].split('/')[-1]
+    land_yes = os.path.join(ERA_DIR, ERA_FIELDN, yyyy)
+    era_files = glob(os.path.join(land_yes, ERA_FIELDN + '*' + yyyy + mm + '*nc'))
+    era5_fname = os.path.join(land_yes, os.path.basename(era_files[0]))
     generic_era5_fname = era5_fname.replace('swvl1', 'FIELDN')
 
     # Path to input file 


### PR DESCRIPTION
The scripts have been tested with the current `u-dh821` version of the Regional Nesting Suite, and they run to completion in that context.
