### PR TITLE
Fixing broken paths in the BARRA replace land scripts and commenting out diagnostic printing.

### DIFF
--- a/src/replace_landsurface/replace_landsurface_with_BARRA2R_IC.py
+++ b/src/replace_landsurface/replace_landsurface_with_BARRA2R_IC.py
@@ -25,10 +25,10 @@ class ReplaceOperator(mule.DataOperator):
     def __init__(self):
         pass
     def new_field(self, sources):
-        print('new_field')
+        #print('new_field')
         return sources[0]
     def transform(self, sources, result):
-        print('transform')
+        #print('transform')
         return sources[1]
 
 
@@ -189,7 +189,7 @@ def swap_land_barra(mask_fullpath, ec_cb_file_fullpath, ic_date):
 
     # Path to output file
     ff_out = ec_cb_file_fullpath.as_posix()
-    print(ff_in, ff_out)
+    #print(ff_in, ff_out)
     
     # Read input file
     mf_in = mule.load_umfile(ff_in)
@@ -199,8 +199,8 @@ def swap_land_barra(mask_fullpath, ec_cb_file_fullpath, ic_date):
 
     # Read in the surface temperature data from the archive
     BARRA_FIELDN = 'ts'
-    indir = BARRA_DIR + '1hr/' + BARRA_FIELDN + '/latest'
-    barra_files = glob(indir + '/' + BARRA_FIELDN + '*' + yyyy + mm + '*nc')
+    indir = os.path.join(BARRA_DIR, '1hr',BARRA_FIELDN, 'latest')
+    barra_files = glob(os.path.join(indir, BARRA_FIELDN + '*' + yyyy + mm + '*nc'))
     barra_fname = indir + '/' + barra_files[0].split('/')[-1]
 
     # Work out the grid bounds using the surface temperature file
@@ -212,16 +212,16 @@ def swap_land_barra(mask_fullpath, ec_cb_file_fullpath, ic_date):
     
     # Read in the soil moisture data (and keep to use for replacement)
     BARRA_FIELDN = 'mrsol'
-    indir = BARRA_DIR + '/3hr/' + BARRA_FIELDN + '/latest'
-    barra_files = glob(indir + '/' + BARRA_FIELDN + '*' + yyyy + mm + '*nc')
+    indir = os.path.join(BARRA_DIR, '3hr',BARRA_FIELDN, 'latest')
+    barra_files = glob(os.path.join(indir, BARRA_FIELDN + '*' + yyyy + mm + '*nc'))
     barra_fname = indir + '/' + barra_files[0].split('/')[-1]
     data = get_BARRA_nc_data(barra_fname, BARRA_FIELDN, ic_date.replace('T', '').replace('Z', ''), 4, bounds)
     mrsol = data.copy()
 
     # Read in the soil temperature data (and keep to use for replacement)
     BARRA_FIELDN = 'tsl'
-    indir = BARRA_DIR + '3hr/' + BARRA_FIELDN + '/latest'
-    barra_files = glob(indir + '/' + BARRA_FIELDN + '*' + yyyy + mm + '*nc')
+    indir = os.path.join(BARRA_DIR, '3hr',BARRA_FIELDN, 'latest')
+    barra_files = glob(os.path.join(indir, BARRA_FIELDN + '*' + yyyy + mm + '*nc'))
     barra_fname = indir + '/' + barra_files[0].split('/')[-1]
     data = get_BARRA_nc_data(barra_fname, BARRA_FIELDN, ic_date.replace('T', '').replace('Z', ''), 4, bounds)
     tsl = data.copy()
@@ -232,7 +232,7 @@ def swap_land_barra(mask_fullpath, ec_cb_file_fullpath, ic_date):
     # For each field in the input write to the output file (but modify as required)
     for f in mf_in.fields:
     
-      print(f.lbuser4, f.lblev, f.lblrec, f.lbhr, f.lbcode)
+      #print(f.lbuser4, f.lblev, f.lblrec, f.lbhr, f.lbcode)
       if f.lbuser4 == 9:
         # replace coarse soil moisture with high-res information
         current_data = f.get_data()

--- a/src/replace_landsurface/replace_landsurface_with_ERA5land_IC.py
+++ b/src/replace_landsurface/replace_landsurface_with_ERA5land_IC.py
@@ -28,10 +28,10 @@ class ReplaceOperator(mule.DataOperator):
     def __init__(self):
         pass
     def new_field(self, sources):
-        print('new_field')
+        #print('new_field')
         return sources[0]
     def transform(self, sources, result):
-        print('transform')
+        #print('transform')
         return sources[1]
 
 class bounding_box():
@@ -140,7 +140,7 @@ def get_ERA_nc_data(ncfname, FIELDN, wanted_dt, bounds):
     latmin_index, latmax_index = bounds.latmin, bounds.latmax
 
     # Open the file containing the data
-    print(ncfname, FIELDN)
+    #print(ncfname, FIELDN)
     if Path(ncfname).exists():
         d = xr.open_dataset(ncfname)
     else:
@@ -150,7 +150,7 @@ def get_ERA_nc_data(ncfname, FIELDN, wanted_dt, bounds):
     # Find the array index for the date/time of interest
     times=d['time'].dt.strftime("%Y%m%d%H%M").data
     TM=times.tolist().index(wanted_dt)
-    print(TM)
+    #print(TM)
 
     # Read the data
     if lonmin_index < lonmax_index: 
@@ -220,7 +220,7 @@ def swap_land_era5land(mask_fullpath, ic_file_fullpath, ic_date):
     ic_file = ic_file_fullpath.parts[-1].replace('.tmp', '')
    
     # create date/time useful information
-    print(ic_date)
+    #print(ic_date)
     yyyy = ic_date[0:4]
     mm = ic_date[4:6]
     ic_z_date = ic_date.replace('T', '').replace('Z', '')
@@ -238,7 +238,7 @@ def swap_land_era5land(mask_fullpath, ic_file_fullpath, ic_date):
 
     # Path to output file 
     ff_out = ic_file_fullpath.as_posix()
-    print(ff_in, ff_out)
+    #print(ff_in, ff_out)
    
     # Read input file
     mf_in = mule.load_umfile(ff_in)
@@ -255,7 +255,7 @@ def swap_land_era5land(mask_fullpath, ic_file_fullpath, ic_date):
     # For each field in the input write to the output file (but modify as required)
     for f in mf_in.fields:
     
-      print(f.lbuser4, f.lblev, f.lblrec, f.lbhr, f.lbcode)
+      #print(f.lbuser4, f.lblev, f.lblrec, f.lbhr, f.lbcode)
 
       if f.lbuser4 == 9:
         # replace coarse soil moisture with high-res information


### PR DESCRIPTION
The paths to the BARRA replace land scripts had become broken (missing "/" between directory names).

The paths have been fixed and diagnostic printing has been commented out at the same time.