### PR TITLE
Set integration tests

### DIFF
--- a/.conda/env_dev.yml
+++ b/.conda/env_dev.yml
@@ -1,0 +1,14 @@
+channels:
+  - accessnri
+  - conda-forge
+  - coecms
+  - nodefaults
+
+dependencies:
+  - mule
+  - numpy <= 1.23.4 # https://stackoverflow.com/a/75148219/21024780
+  - scitools-iris
+  - xarray
+  - versioneer
+  - pytest
+  - hypothesis

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 test_data/
 .coverage
-*.sh
 __pycache__/
 *.py[cod]
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,39 @@
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
-
 # replace_landsurface
 
-This repository contains Python scripts for use by Regional Nesting Suites to replace specific land surface fields in static input data.
+## About
+
+`replace_landsurface` is a `Python` utility to be used within ACCESS-NRI versions of the Regional Nesting Suites to replace specific land surface initial/boundary conditions.
+
+
+## Development/Testing instructions
+For development/testing, it is recommended to install `replace_landsurface` as a development package within a `micromamba`/`conda` testing environment.
+
+### Clone replace_landsurface GitHub repo
+```
+git clone git@github.com:ACCESS-NRI/replace_landsurface.git
+```
+
+### Create a micromamba/conda testing environment
+> [!TIP]  
+> In the following instructions `micromamba` can be replaced with `conda`.
+
+```
+cd replace_landsurface
+micromamba env create -n replace_landsurface_dev --file .conda/env_dev.yml
+micromamba activate replace_landsurface_dev
+```
+
+### Install replace_landsurface as a development package
+```
+pip install --no-deps --no-build-isolation -e .
+```
+
+### Running the tests
+
+#### Integration tests
+To manually run the integration tests, from the `replace_landsurface` directory, you can:
+1. Activate your [micromamba/conda testing environment](#create-a-micromamba-conda-testing-environment)
+2. Run the following command:
+   ```
+   bash integration/integration_tests.sh
+   ```

--- a/integration/INTEGRATION_README.md
+++ b/integration/INTEGRATION_README.md
@@ -1,0 +1,80 @@
+# Integration tests for replace_landsurface
+
+`integration_tests.sh` is a basic binary compatibility test script for replace_landsurface,
+that compares the outputs of a specific version of the `replace_landsurface` package with their expected outputs.
+The script warns the user if the outputs do not match their respective expected versions.
+
+The tests are designed to be run on Gadi within a Python environment where `replace_landsurface` is installed as a development package (for instructions refer to the Installation paragraph in the README).
+<!-- The tests also require `nccmp` to be installed. 
+To make sure the `nccmp` requirement is satisfied, it is recommended to install `um2nc` within the `.conda/env_dev.yml` conda environment. -->
+
+<!-- Usage:
+    regression_tests.sh [--keep] [-d DATA_CHOICE] [-v DATA_VERSION]
+
+Options:
+    -k, --keep            Keep output netCDF data upon test completion.
+                          If absent, output netCDF data will only be kept for failed test sessions. 
+    -d    DATA_CHOICE     Choice of test reference data.
+                          Options: "full", "intermediate", "light".
+                          Default: "intermediate".
+    -v    DATA_VERSION    Version of test reference data to use.
+                          Options: "0".
+                          Default: latest release version -->
+
+## Data choices
+Three types of reference data are available for use in the tests, called "full",
+"intermediate", and "light". Each group of data contains a fields file, and
+netCDF files produced from converting the fields file using various `um2nc` options.
+
+### Full
+The "full" fields file is an output file from an ESM1.5 simulation.
+Running tests with the "full" data is slower and more resource-intensive.
+
+### Intermediate (default)
+The "intermediate" data contains a fields file, generated as a subset of the
+the variables from the "full" data. These variables were selected to ensure
+different portions of code within `um2nc` are used in the integration tests.
+The included variables are:
+
+* m01s00i024 Surface temperature (a simple 2D field)
+* m01s00i407 Pressure on model rho levels
+* m01s00i408 Pressure on model theta levels
+* m01s02i288 Aerosol optical thickness from biomass burning (a variable on pseudo_levels)
+* m01s03i209 Eastward wind (tests hardcoded variable name changes)
+* m01s03i321 Canopy water on tiles (a tiled variable)
+* m01s05i216 Precipitation (a simple 2D field)
+* m01s08i208 Soil moisture (land only data)
+* m01s08i223 Soil moisture on soil levels
+* m01s30i204 Temperature on PLEV grid (requires masking)
+* m01s30i301 Heaviside (used for masking)
+
+### Light
+The "light" data contains a minimal subset of variables from the "full" data
+fields file, and can be used for faster but less in-depth testing. It includes:
+
+* m01s30i204 Temperature on PLEV grid
+* m01s05i216 Precipitation
+
+### Comparison data
+For each of the above data choices, the following netCDF variants were produced:
+
+* `mask`: produced with the `--nohist` flag only.
+* `nomask`: produced with the `--nomask` and `--nohist` flags.
+* `hist`: produced with no flags. These files will have a conversion datestamp
+in their history attribute.
+
+## Data versions
+The `um2nc` version to compare against can be selected with the `-v` flag.
+If omitted, the tests will be performed against the latest released version.
+
+Available versions for comparison are:
+* 0
+
+### Version `0`
+Version `0` netCDF outputs were created using the `um2netcdf.py` script available
+prior to the development of `um2nc`: https://github.com/ACCESS-NRI/um2nc-standalone/blob/f62105b45eb39d2beed5a7ac71f439ff90f0f00c/src/um2netcdf.py
+
+The conversion was performed within the following `payu1.1.5` environment, active on Gadi:
+https://github.com/ACCESS-NRI/payu-condaenv/releases/tag/1.1.5
+
+All test data is located in `/g/data/vk83/testing/data/um2nc/integration-tests`.

--- a/integration/INTEGRATION_README.md
+++ b/integration/INTEGRATION_README.md
@@ -1,80 +1,28 @@
 # Integration tests for replace_landsurface
 
-`integration_tests.sh` is a basic binary compatibility test script for replace_landsurface,
-that compares the outputs of a specific version of the `replace_landsurface` package with their expected outputs.
-The script warns the user if the outputs do not match their respective expected versions.
+`integration_tests.sh` is a basic binary compatibility test script for the replace_landsurface package.
+
+The script executes various tests in parallel, for all the entry points of the package, using different options to test multiple cases.
+
+All multiple tests are executed to completion, even if any of them fails.
+When all the tests are completed, the script fails if any of the tested returned a non-zero exit code, and a message is printed with information about the failed test.
 
 The tests are designed to be run on Gadi within a Python environment where `replace_landsurface` is installed as a development package (for instructions refer to the Installation paragraph in the README).
-<!-- The tests also require `nccmp` to be installed. 
-To make sure the `nccmp` requirement is satisfied, it is recommended to install `um2nc` within the `.conda/env_dev.yml` conda environment. -->
 
-<!-- Usage:
-    regression_tests.sh [--keep] [-d DATA_CHOICE] [-v DATA_VERSION]
+Usage:
+    regression_tests.sh [-h] [--keep]
 
 Options:
-    -k, --keep            Keep output netCDF data upon test completion.
-                          If absent, output netCDF data will only be kept for failed test sessions. 
-    -d    DATA_CHOICE     Choice of test reference data.
-                          Options: "full", "intermediate", "light".
-                          Default: "intermediate".
-    -v    DATA_VERSION    Version of test reference data to use.
-                          Options: "0".
-                          Default: latest release version -->
+    -h, --help          Print this usage information and exit.
+    -k, --keep          Force output data to be kept upon test completion.
+                        The default behaviour is to keep the output data only for failed test sessions and delete it if all tests pass.
 
-## Data choices
-Three types of reference data are available for use in the tests, called "full",
-"intermediate", and "light". Each group of data contains a fields file, and
-netCDF files produced from converting the fields file using various `um2nc` options.
+All test data is located in `/g/data/vk83/testing/data/replace_landsurface/integration_tests`.
 
-### Full
-The "full" fields file is an output file from an ESM1.5 simulation.
-Running tests with the "full" data is slower and more resource-intensive.
+### Tests performed
 
-### Intermediate (default)
-The "intermediate" data contains a fields file, generated as a subset of the
-the variables from the "full" data. These variables were selected to ensure
-different portions of code within `um2nc` are used in the integration tests.
-The included variables are:
-
-* m01s00i024 Surface temperature (a simple 2D field)
-* m01s00i407 Pressure on model rho levels
-* m01s00i408 Pressure on model theta levels
-* m01s02i288 Aerosol optical thickness from biomass burning (a variable on pseudo_levels)
-* m01s03i209 Eastward wind (tests hardcoded variable name changes)
-* m01s03i321 Canopy water on tiles (a tiled variable)
-* m01s05i216 Precipitation (a simple 2D field)
-* m01s08i208 Soil moisture (land only data)
-* m01s08i223 Soil moisture on soil levels
-* m01s30i204 Temperature on PLEV grid (requires masking)
-* m01s30i301 Heaviside (used for masking)
-
-### Light
-The "light" data contains a minimal subset of variables from the "full" data
-fields file, and can be used for faster but less in-depth testing. It includes:
-
-* m01s30i204 Temperature on PLEV grid
-* m01s05i216 Precipitation
-
-### Comparison data
-For each of the above data choices, the following netCDF variants were produced:
-
-* `mask`: produced with the `--nohist` flag only.
-* `nomask`: produced with the `--nomask` and `--nohist` flags.
-* `hist`: produced with no flags. These files will have a conversion datestamp
-in their history attribute.
-
-## Data versions
-The `um2nc` version to compare against can be selected with the `-v` flag.
-If omitted, the tests will be performed against the latest released version.
-
-Available versions for comparison are:
-* 0
-
-### Version `0`
-Version `0` netCDF outputs were created using the `um2netcdf.py` script available
-prior to the development of `um2nc`: https://github.com/ACCESS-NRI/um2nc-standalone/blob/f62105b45eb39d2beed5a7ac71f439ff90f0f00c/src/um2netcdf.py
-
-The conversion was performed within the following `payu1.1.5` environment, active on Gadi:
-https://github.com/ACCESS-NRI/payu-condaenv/releases/tag/1.1.5
-
-All test data is located in `/g/data/vk83/testing/data/um2nc/integration-tests`.
+- Test 1: hres_ic with `--type era5land`
+- Test 2: hres_ic with `--type barra`
+- Test 3: hres_ic with `--type astart`
+- Test 4: hres_eccb with `--type era5land` (CURRENTLY NOT AVAILABLE)
+- Test 5: hres_eccb with `--type barra` (CURRENTLY NOT AVAILABLE)

--- a/integration/integration_tests.sh
+++ b/integration/integration_tests.sh
@@ -31,11 +31,12 @@ functrap() {
 trap "exit 2" SIGHUP SIGINT SIGQUIT SIGILL SIGABRT SIGTERM SIGSTOP
 trap functrap EXIT
 
+start_time=$(date +%s)
 #Set up the work directory as a copy of the test data directory
 echo "Setting up work directory..."
 cp -r $INPUT_DIR/* $WORK_DIR
 cd $WORK_DIR
-
+echo "Elapsed time for data copy: $(($(date +%s) - start_time)) seconds"
 
 function usage {
     cat << EOF

--- a/integration/integration_tests.sh
+++ b/integration/integration_tests.sh
@@ -9,6 +9,8 @@ OUTPUT_DIR=$TEST_DATA_DIR/expected_outputs
 DRIVING_DATA_DIR=$TEST_DATA_DIR/driving_data
 CLEAN_OUTPUT=true
 
+declare -A pids # Associative array (similar to a dictionary in Python)
+
 # Create a temporary work directory
 WORK_DIR=$(mktemp -d)
 echo -e "Work directory: $WORK_DIR\n"
@@ -106,7 +108,6 @@ run_test() {
     compare
 }
 # # -----------------------------------------------------------------
-declare -A pids # Associative array (similar to a dictionary in Python)
 # Test hres_ic
 entry_point=hres_ic
 
@@ -119,7 +120,7 @@ TYPE=era5land
 START=202202260000
 
 echo "### Test 1: hres_ic, type 'era5land' ###"
-run_test & pids[1]+=$!
+run_test > /dev/null & pids[1]+=$!
 
 # # Test 2: 'barra'
 # MASK=/scratch/tm70/cbe563/cylc-run/u-dg767.b/share/data/ancils/Lismore/d1100/qrparm.mask
@@ -130,7 +131,7 @@ TYPE=barra
 START=202008090000
 
 echo "### Test 2: hres_ic, type 'barra' ###"
-run_test & pids[2]+=$!
+run_test > /dev/null & pids[2]+=$!
 
 # # Test 2: 'barra'
 # MASK=/scratch/tm70/cbe563/cylc-run/u-dg767/share/data/ancils/Lismore/d0198/qrparm.mask
@@ -141,7 +142,7 @@ TYPE=astart
 START=202112310000
 
 echo "### Test 3: hres_ic, type 'astart' ###"
-run_test & pids[3]+=$!
+run_test > /dev/null & pids[3]+=$!
 
 
 # Capture the exit status of each background processes dynamically

--- a/integration/integration_tests.sh
+++ b/integration/integration_tests.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# Basic binary compatibility test script for replace_landsurface.
+# See INTEGRATION_README.md for details on test usage, data and options.
+
+TEST_DATA_DIR=/g/data/tm70/dm5220/projects/replace_landsurface/test_data
+INPUT_DIR=$TEST_DATA_DIR/input_data
+OUTPUT_DIR=$TEST_DATA_DIR/expected_outputs
+DRIVING_DATA_DIR=$TEST_DATA_DIR/driving_data
+CLEAN_OUTPUT=true
+
+# Create a temporary work directory
+WORK_DIR=$(mktemp -d)
+echo -e "Work directory: $WORK_DIR\n"
+# Trap signals to clean up WORK directory depending on exit status
+functrap() {
+    code="$?"
+    if ([ "$code" -eq 0 ] && $CLEAN_OUTPUT) || [ "$code" -eq 2 ]; then
+        rm -rf "$WORK_DIR"
+        echo "Work directory cleaned up."
+    fi
+}
+# Separate the cases when the script is interrupted, from the cases when it's not
+trap "exit 2" SIGHUP SIGINT SIGQUIT SIGILL SIGABRT SIGTERM
+trap functrap EXIT
+
+#Set up the work directory as a copy of the test data directory
+echo "Setting up work directory..."
+cp -r $INPUT_DIR/* $WORK_DIR
+cd $WORK_DIR
+
+
+function usage {
+    cat << EOF
+Basic binary compatibility test script for 'replace_landsurface'.
+Checks that the outputs of the 'replace_landsurface' package entry points correspond to the expected outputs.
+
+Usage: regression_tests.sh [-k/--keep]
+
+Options:
+-k, --keep            Keep output data upon test completion. 
+                      If absent, output data will only be kept for failed tests.
+EOF
+}
+
+while getopts ":-:hk" opt; do
+    case ${opt} in
+        -)
+            case ${OPTARG} in
+                help)
+                    usage
+                    exit 0
+                ;;
+                keep)
+                    CLEAN_OUTPUT=false
+                ;;
+                *)
+                    echo "Invalid option: \"--${OPTARG}\"." >&2
+                    usage
+                    exit 1
+                ;;
+            esac
+        ;;
+        h)
+            usage
+            exit 0
+        ;;
+        k)
+            CLEAN_OUTPUT=true
+        ;;
+        \?)
+            echo "Invalid option: \"-${OPTARG}\"." >&2
+            usage
+            exit 1
+        ;;
+    esac
+done
+
+# Check that no additional arguments were passed.
+if [[ -n "${@:$OPTIND:1}" ]]; then
+    echo "Invalid positional argument: \"${@:$OPTIND:1}\"." >&2
+    exit 1
+fi
+
+# # -----------------------------------------------------------------
+# # Run the tests
+# # -----------------------------------------------------------------
+echo "Running tests..."
+
+export ROSE_DATA=$DRIVING_DATA_DIR
+run_command() {
+    MASK=$WORK_DIR/$test_dir/mask
+    FILE=$WORK_DIR/$test_dir/file
+    HRES_IC=$WORK_DIR/$test_dir/hres_ic
+    eval "$entry_point --mask $MASK --file ${FILE}.tmp --start $START --hres_ic $HRES_IC --type $TYPE"
+}
+compare() {
+    cmp $WORK_DIR/$test_dir/file $OUTPUT_DIR/$test_dir
+    if [ $? -ne 0 ]; then
+        echo "Test ${test_dir#test} failed."
+        exit 1
+    fi
+}
+# # -----------------------------------------------------------------
+# Test hres_ic
+entry_point=hres_ic
+
+# Test 1: 'era5land'
+# MASK=/scratch/tm70/cbe563/cylc-run/u-dg767/share/data/ancils/Lismore/d1000/qrparm.mask
+# FILE=g/data/tm70/cbe563/test_replace_land_surface/ERA5LAND/GAL9_astart
+# HRES_IC=NOT_SET
+test_dir=test_1
+TYPE=era5land
+START=202202260000
+
+echo "### Test 1: hres_ic, type 'era5land' ###"
+run_command
+compare
+
+# # Test 2: 'barra'
+# MASK=/scratch/tm70/cbe563/cylc-run/u-dg767.b/share/data/ancils/Lismore/d1100/qrparm.mask
+# FILE=/g/data/tm70/cbe563/test_replace_land_surface/BARRAR2/GAL9_astart
+# HRES_IC=NOT_SET
+test_dir=test_2
+TYPE=barra
+START=202008090000
+
+echo "### Test 2: hres_ic, type 'barra' ###"
+run_command
+compare
+
+# # Test 2: 'barra'
+# MASK=/scratch/tm70/cbe563/cylc-run/u-dg767/share/data/ancils/Lismore/d0198/qrparm.mask
+# FILE=/g/data/tm70/cbe563/test_replace_land_surface/ASTART/RAL3P2_astart
+# HRES_IC=/scratch/tm70/cbe563/cylc-run/u-dg768.worked/share/cycle/20220226T0000Z/Lismore/d0198/RAL3P2/ics/RAL3P2_astart
+test_dir=test_3
+TYPE=astart
+START=202112310000
+
+echo "### Test 3: hres_ic, type 'astart' ###"
+run_command
+compare

--- a/integration/integration_tests.sh
+++ b/integration/integration_tests.sh
@@ -119,7 +119,7 @@ entry_point=hres_ic
 
 # Test 1: 'era5land'
 # MASK=/scratch/tm70/cbe563/cylc-run/u-dg767/share/data/ancils/Lismore/d1000/qrparm.mask
-# FILE=g/data/tm70/cbe563/test_replace_land_surface/ERA5LAND/GAL9_astart
+# FILE=/g/data/tm70/cbe563/test_replace_land_surface/ERA5LAND/GAL9_astart
 # HRES_IC=NOT_SET
 test_dir=test_1
 TYPE=era5land
@@ -139,7 +139,7 @@ START=202008090000
 echo "### Test 2: hres_ic, type 'barra' ###"
 run_test > /dev/null & pids[2]+=$!
 
-# # Test 2: 'barra'
+# # Test 3: 'astart'
 # MASK=/scratch/tm70/cbe563/cylc-run/u-dg767/share/data/ancils/Lismore/d0198/qrparm.mask
 # FILE=/g/data/tm70/cbe563/test_replace_land_surface/ASTART/RAL3P2_astart
 # HRES_IC=/scratch/tm70/cbe563/cylc-run/u-dg768.worked/share/cycle/20220226T0000Z/Lismore/d0198/RAL3P2/ics/RAL3P2_astart

--- a/src/replace_landsurface/replace_landsurface_with_ERA5land_IC.py
+++ b/src/replace_landsurface/replace_landsurface_with_ERA5land_IC.py
@@ -215,10 +215,6 @@ def swap_land_era5land(mask_fullpath, ic_file_fullpath, ic_date):
         The file is replaced with a version of itself holding the higher-resolution data.
     """
 
-
-    # create name of file to be replaced
-    ic_file = ic_file_fullpath.parts[-1].replace('.tmp', '')
-   
     # create date/time useful information
     #print(ic_date)
     yyyy = ic_date[0:4]


### PR DESCRIPTION
This PR sets up the integration tests. 
Fixes #46 (after [all tests are added](#added-tests))

- [x] Added integration test script [integration_tests.sh](https://github.com/ACCESS-NRI/replace_landsurface/blob/davide/integration_tests/integration/integration_tests.sh). The script tests multiple options/entry_points in parallel. It fails if any of the tests fail (but continues the execution until all test complete) and prints a message related to the failed test.
- [x] Added INTEGRATION_README 
- [x] Updated README with information about development/testing 

## Overview

The `integration_tests.sh` script executes various tests in parallel, for all the entry points of the package, using different options to test multiple cases.

All multiple tests are executed (in parallel) to completion, even if any of them fails.
When all the tests are completed, the script fails if any of the tested returned a non-zero exit code, and a message is printed with information about the failed tests.

The tests are designed to be run on `Gadi` within a `Python` environment where `replace_landsurface` is installed as a development package. Instruction for the installation of the development environment have been added in the README.

<h3 id='data'>Data</h3>
All test data is located in `/g/data/vk83/testing/data/replace_landsurface/integration_tests`.
At the start of the script, this data gets copied to a temporary working directory where the tests are run, to avoid modifying the original input data. 
<span id='output_option'></span>

> [!IMPORTANT]
> This is especially important because the `replace_lansurface` functions replace the input data with the new modified version, therefore copying the input data before running the script is essential to avoid changing the original testing data.
> This could only be avoided by adding an `--output` option to the functions, that could default to the input file name (replacing the file and therefore keeping the behaviour as it is currently).

### Tests performed

- Test 1: `hres_ic` with `--type era5land`
- Test 2: `hres_ic` with `--type barra`
- Test 3: `hres_ic` with `--type astart`
- Test 4: `hres_eccb` with `--type era5land` (CURRENTLY NOT AVAILABLE)
- Test 5: `hres_eccb` with `--type barra` (CURRENTLY NOT AVAILABLE)
<span id='added-tests'></span>

> [!IMPORTANT]
> Tests 4 and 5 are still not present in the testing script, as data for these tests needs to be provided (more information in [#46](https://github.com/ACCESS-NRI/replace_landsurface/issues/46#issuecomment-2657974927)).
> I suggest waiting for these tests to be added before merging this PR.

### Profiling
The test currently takes around 2:50m to complete, of which \~1m is spent to [copy the files](#data) (there is currently a [portion in the test script](https://github.com/ACCESS-NRI/replace_landsurface/blob/8f2ecfb4792dd84fc1351eadd0aced31d1506a89/integration/integration_tests.sh#L34-L39) that prints roughly prints out the time spent for copying the data. This was only added for testin/profiling purposes and could be removed before merging).
Adding more tests would not increase much the time spent to run the actual tests (because they are run in parallel), but would increase the time spent to copy the data, especially because the input data is pretty big (~ 45GB at the moment, with the potential to be ~ 75GB when the 2 remaining tests are added).
I highly suggest adding the `--output` option mentioned [here](#output_option)

Further information and usage instructions can be found in the [INTEGRATION_README](https://github.com/ACCESS-NRI/replace_landsurface/blob/davide/integration_tests/integration/INTEGRATION_README.md).