### PR TITLE
Avoid polluting service user account with micromamba files

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -142,13 +142,15 @@ jobs:
         run: |
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           set -e
-          chmod -R g+r,g+x ${{ steps.create-tmp-dir.outputs.tmp_dir }}
-          env_prefix=${{ steps.create-tmp-dir.outputs.tmp_dir }}/environment_${{github.sha}}
-          env_file=${{ steps.create-tmp-dir.outputs.tmp_dir }}/${{ github.event.repository.name }}/.conda/env_dev.yml
+          tmp_dir='${{ steps.create-tmp-dir.outputs.tmp_dir }}'
+          chmod -R g+r,g+x "$tmp_dir"
+          export MAMBA_ROOT_PREFIX="$tmp_dir"
+          env_prefix=${tmp_dir}/environment_${{github.sha}}
+          env_file=${tmp_dir}/${{ github.event.repository.name }}/.conda/env_dev.yml
           cleanup() {
             # Remove micromamba environment whenever the script exits
             ${{ vars.MICROMAMBA_EXE }} env remove --prefix $env_prefix --yes &> /dev/null
-            rm -rf '${{ steps.create-tmp-dir.outputs.tmp_dir }}'
+            rm -rf "$tmp_dir"
             echo "Micromamba environment and temporary directory removed."
           }
           trap cleanup EXIT
@@ -163,7 +165,7 @@ jobs:
           echo "  Command: $cmd"
           eval "$cmd"
           # Run tests (using 4 workers in parallel)
-          cmd="${{ vars.MICROMAMBA_EXE }} run --prefix $env_prefix pytest -n 4 ${{ steps.create-tmp-dir.outputs.tmp_dir }}/${{ github.event.repository.name }}"
+          cmd="${{ vars.MICROMAMBA_EXE }} run --prefix $env_prefix pytest -n 4 ${tmp_dir}/${{ github.event.repository.name }}"
           echo "Running tests"
           echo "  Command: $cmd"
           eval "$cmd"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -160,7 +160,7 @@ jobs:
           echo "  Environment file: $env_file"
           ${{ vars.MICROMAMBA_EXE }} create --prefix $env_prefix --file $env_file --yes
           # Install package as development
-          cmd="${{ vars.MICROMAMBA_EXE }} run --prefix $env_prefix pip install --no-deps --no-build-isolation ${{ steps.create-tmp-dir.outputs.tmp_dir }}/${{ github.event.repository.name }}"
+          cmd="${{ vars.MICROMAMBA_EXE }} run --prefix $env_prefix pip install --no-deps --no-build-isolation ${tmp_dir}/${{ github.event.repository.name }}"
           echo "Installing '${{ github.event.repository.name }}'"
           echo "  Command: $cmd"
           eval "$cmd"


### PR DESCRIPTION
## Background
Currently, the `micromamba create` command within the testing job creates environment in a custom folder, but still uses/stores cache packages in the default location. 
This ends up polluting the `~/.local` folder of the service user, which should not happen.

## Solution
Before running the `micromamba create` command, set the `MAMBA_ROOT_PREFIX` env variable to the temporary folder (deleted at the end of the workflow), so the cache would automatically be stored there instead.

## Tasks carried out

- [x] Added line to export `MAMBA_ROOT_PREFIX` env variable, to avoid polluting the service user with micromamba-related files
- [x] Set  `tmp_dir` equal to `${{ steps.create-tmp-dir.outputs.tmp_dir }}` and replaced multiple occurrences of `${{ steps.create-tmp-dir.outputs.tmp_dir }}` with it