### PR TITLE
Error handling when user can't access BARRA files

### DIFF
--- a/src/replace_landsurface/replace_landsurface_with_BARRA2R_IC.py
+++ b/src/replace_landsurface/replace_landsurface_with_BARRA2R_IC.py
@@ -202,7 +202,7 @@ def swap_land_barra(mask_fullpath, ec_cb_file_fullpath, ic_date):
     indir = os.path.join(BARRA_DIR, '1hr',BARRA_FIELDN, 'latest')
     barra_files = glob(os.path.join(indir, BARRA_FIELDN + '*' + yyyy + mm + '*nc'))
     if not barra_files:
-        raise ImportError("BARRA files not found. This most likely means you're not a member of the ob53 group.")
+        raise FileNotFoundError("BARRA files not found. This most likely means you're not a member of the ob53 group.")
     barra_fname = indir + '/' + barra_files[0].split('/')[-1]
 
     # Work out the grid bounds using the surface temperature file

--- a/src/replace_landsurface/replace_landsurface_with_BARRA2R_IC.py
+++ b/src/replace_landsurface/replace_landsurface_with_BARRA2R_IC.py
@@ -201,6 +201,8 @@ def swap_land_barra(mask_fullpath, ec_cb_file_fullpath, ic_date):
     BARRA_FIELDN = 'ts'
     indir = os.path.join(BARRA_DIR, '1hr',BARRA_FIELDN, 'latest')
     barra_files = glob(os.path.join(indir, BARRA_FIELDN + '*' + yyyy + mm + '*nc'))
+    if not barra_files:
+        raise ImportError("BARRA files not found. This most likely means you're not a member of the ob53 group.")
     barra_fname = indir + '/' + barra_files[0].split('/')[-1]
 
     # Work out the grid bounds using the surface temperature file


### PR DESCRIPTION
Currently the error thrown if a user isn't yet on ob53 is cryptic, and not obviously a `file not found` issue. This explicitly tells the user what's wrong if the `barra_files` list is empty